### PR TITLE
Only take one config per relation

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -11,8 +11,7 @@ class OidcClientRequirer(Endpoint):
 
     def get_config(self):
         return [
-            json.loads(unit.received_raw["client_info"])
+            json.loads(relation.joined_units.received_raw["client_info"])
             for relation in self.relations
-            for unit in relation.joined_units
-            if unit.received_raw.get('client_info')
+            if relation.joined_units.received_raw.get('client_info')
         ]


### PR DESCRIPTION
Neither charm-helpers nor charms.reactive support application-level relation data yet.  This workaround fixes #1 in the short term until the app rel data support can be added to the libraries.